### PR TITLE
Enable auto-merge for minor updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
This PR updates the Renovate configuration to enable auto-merging for minor updates, patches, pins, and digests. This will help streamline dependency management by automatically merging non-breaking changes.