### PR TITLE
fix: update Clojure to 1.11.1 to support integrant 0.13.1

### DIFF
--- a/back-end/project.clj
+++ b/back-end/project.clj
@@ -21,7 +21,7 @@
                  [compojure "1.7.1"]
                  [cheshire "5.13.0"]
                  [cljstache "2.0.6"]
-                 [integrant "0.8.0"]
+                 [integrant "0.13.1"]
                  [org.clojure/tools.namespace "0.3.1"]
                  [com.walmartlabs/lacinia "0.38.0"]
                  [e85th/venia "0.2.5-1"]

--- a/back-end/project.clj
+++ b/back-end/project.clj
@@ -5,7 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :plugins [[lein-bom "0.2.0-SNAPSHOT"]]
   :bom {:import [[com.google.cloud/libraries-bom "23.0.0"]]}
-  :dependencies [[org.clojure/clojure "1.10.1"]
+  :dependencies [[org.clojure/clojure "1.11.1"]
                  [org.clojure/core.async "0.7.559"]
                  [org.clojure/data.codec "0.1.1"]
                  [org.clojure/test.check "0.10.0"]


### PR DESCRIPTION
This PR fixes the CI failure in PR #196 by updating the Clojure version to 1.11.1, which is required by integrant 0.13.1 as mentioned in the [integrant changelog](https://github.com/weavejester/integrant/blob/514081c136401c48c33bfe53523bd5fc18ebe5e3/CHANGELOG.md?plain=1#L52).