### PR TITLE
フロントエンドビルドCIにSSRサーバーテストを追加

### DIFF
--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -65,6 +65,40 @@ jobs:
             exit 1
           fi
           echo "Frontend Docker build succeeded"
+
+      - name: Test SSR server startup
+        run: |
+          # Start container and test if SSR server starts up properly
+          docker run -d --name ssr-test -p 3000:3000 vr-match-frontend:test
+          
+          # Wait for server to start
+          echo "Waiting for SSR server to start..."
+          sleep 10
+          
+          # Check if server responds
+          MAX_RETRIES=5
+          RETRY_COUNT=0
+          
+          while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 | grep -q "200\|301\|302"; then
+              echo "SSR server is running successfully!"
+              docker logs ssr-test
+              docker stop ssr-test
+              docker rm ssr-test
+              exit 0
+            fi
+            
+            echo "Retry $((RETRY_COUNT+1))/$MAX_RETRIES: SSR server not responding yet..."
+            RETRY_COUNT=$((RETRY_COUNT+1))
+            sleep 5
+          done
+          
+          echo "Failed to start SSR server"
+          docker logs ssr-test
+          docker stop ssr-test
+          docker rm ssr-test
+          exit 1
+
   build-backend:
     name: Build Backend Docker Image
     needs: file-changes

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -33,8 +33,8 @@ jobs:
             workflow:
               - '.github/workflows/docker-build-check.yml'
 
-  build-frontend:
-    name: Build Frontend Docker Image
+  build-and-test:
+    name: Build and Test
     needs: file-changes
     runs-on: ubuntu-latest
     if: |
@@ -66,45 +66,19 @@ jobs:
           fi
           echo "Frontend Docker build succeeded"
 
-      - name: Save Docker image
-        run: |
-          docker save vr-match-frontend:test > /tmp/frontend-image.tar
-
-      - name: Upload Docker image as artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: frontend-docker-image
-          path: /tmp/frontend-image.tar
-          retention-days: 1
-
-  test-ssr-server:
-    name: Test SSR Server
-    needs: build-frontend
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download Docker image
-        uses: actions/download-artifact@v3
-        with:
-          name: frontend-docker-image
-          path: /tmp
-
-      - name: Load Docker image
-        run: |
-          docker load < /tmp/frontend-image.tar
-
       - name: Test SSR server startup
         run: |
           # Start container and test if SSR server starts up properly
           docker run -d --name ssr-test -p 3000:3000 vr-match-frontend:test
-          
+
           # Wait for server to start
           echo "Waiting for SSR server to start..."
           sleep 10
-          
+
           # Check if server responds
           MAX_RETRIES=5
           RETRY_COUNT=0
-          
+
           while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
             if curl -s -o /dev/null -w "%{http_code}" http://localhost:3000 | grep -q "200\|301\|302"; then
               echo "SSR server is running successfully!"
@@ -113,12 +87,12 @@ jobs:
               docker rm ssr-test
               exit 0
             fi
-            
+
             echo "Retry $((RETRY_COUNT+1))/$MAX_RETRIES: SSR server not responding yet..."
             RETRY_COUNT=$((RETRY_COUNT+1))
             sleep 5
           done
-          
+
           echo "Failed to start SSR server"
           docker logs ssr-test
           docker stop ssr-test

--- a/.github/workflows/docker-build-check.yml
+++ b/.github/workflows/docker-build-check.yml
@@ -66,6 +66,32 @@ jobs:
           fi
           echo "Frontend Docker build succeeded"
 
+      - name: Save Docker image
+        run: |
+          docker save vr-match-frontend:test > /tmp/frontend-image.tar
+
+      - name: Upload Docker image as artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: frontend-docker-image
+          path: /tmp/frontend-image.tar
+          retention-days: 1
+
+  test-ssr-server:
+    name: Test SSR Server
+    needs: build-frontend
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download Docker image
+        uses: actions/download-artifact@v3
+        with:
+          name: frontend-docker-image
+          path: /tmp
+
+      - name: Load Docker image
+        run: |
+          docker load < /tmp/frontend-image.tar
+
       - name: Test SSR server startup
         run: |
           # Start container and test if SSR server starts up properly


### PR DESCRIPTION
## 変更内容

フロントエンドのビルドを行うCIに、ビルドしたコンテナでSSRサーバーを立ち上げるテストを追加しました。

### 追加した機能
- PRチェック用のCIワークフロー（docker-build-check.yml）にSSRサーバーのテスト機能を追加
- ビルドしたDockerコンテナを起動し、SSRサーバーが正常に応答するかを確認
- 最大5回のリトライを行い、サーバーの起動を待機
- テスト成功/失敗時にログを出力

### テスト手順
1. コンテナを起動し、SSRサーバーを立ち上げる
2. サーバーの起動を待つ（初期化に10秒待機）
3. サーバーが正常に応答するかを確認（最大5回リトライ）
4. 成功した場合はログを表示して終了、失敗した場合はエラーログを表示して失敗を報告