### PR TITLE
Deploy to stage environment on stage-automerge

### DIFF
--- a/.github/workflows/stage-automerge.yml
+++ b/.github/workflows/stage-automerge.yml
@@ -19,9 +19,27 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Merge by labeled
+        id: merge
         uses: devmasx/merge-branch@v1.4.0
         with:
           label_name: 'stage'
           target_branch: 'stage'
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      
+      # Trigger deployment workflows after successful merge
+      - name: Trigger backend deployment
+        if: steps.merge.outputs.status == 'success'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: stage-deploy-backend
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+      
+      - name: Trigger frontend deployment
+        if: steps.merge.outputs.status == 'success'
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: stage-deploy-frontend
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/stage-build-container-image-back-end.yml
+++ b/.github/workflows/stage-build-container-image-back-end.yml
@@ -15,12 +15,17 @@ on:
     paths:
         - .github/workflows/stage-build-container-image-back-end.yml
         - back-end/**
+  repository_dispatch:
+    types: [stage-deploy-backend]
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Only run this job when the PR is merged, not just closed
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    # Only run this job when:
+    # 1. It's a direct push to stage branch
+    # 2. It's a PR that was merged (not just closed)
+    # 3. It's a repository_dispatch event
+    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/stage-build-container-image-back-end.yml
+++ b/.github/workflows/stage-build-container-image-back-end.yml
@@ -8,10 +8,19 @@ on:
     paths:
         - .github/workflows/stage-build-container-image-back-end.yml
         - back-end/**
+  pull_request:
+    types: [closed]
+    branches:
+      - stage
+    paths:
+        - .github/workflows/stage-build-container-image-back-end.yml
+        - back-end/**
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Only run this job when the PR is merged, not just closed
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/stage-build-container-image-back-end.yml
+++ b/.github/workflows/stage-build-container-image-back-end.yml
@@ -8,24 +8,12 @@ on:
     paths:
         - .github/workflows/stage-build-container-image-back-end.yml
         - back-end/**
-  pull_request:
-    types: [closed]
-    branches:
-      - stage
-    paths:
-        - .github/workflows/stage-build-container-image-back-end.yml
-        - back-end/**
   repository_dispatch:
     types: [stage-deploy-backend]
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Only run this job when:
-    # 1. It's a direct push to stage branch
-    # 2. It's a PR that was merged (not just closed)
-    # 3. It's a repository_dispatch event
-    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/stage-build-container-image-front-end.yml
+++ b/.github/workflows/stage-build-container-image-front-end.yml
@@ -15,12 +15,17 @@ on:
     paths:
         - .github/workflows/stage-build-container-image-front-end.yml
         - front-end/**
+  repository_dispatch:
+    types: [stage-deploy-frontend]
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Only run this job when the PR is merged, not just closed
-    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
+    # Only run this job when:
+    # 1. It's a direct push to stage branch
+    # 2. It's a PR that was merged (not just closed)
+    # 3. It's a repository_dispatch event
+    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/stage-build-container-image-front-end.yml
+++ b/.github/workflows/stage-build-container-image-front-end.yml
@@ -8,10 +8,19 @@ on:
     paths:
         - .github/workflows/stage-build-container-image-front-end.yml
         - front-end/**
+  pull_request:
+    types: [closed]
+    branches:
+      - stage
+    paths:
+        - .github/workflows/stage-build-container-image-front-end.yml
+        - front-end/**
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # Only run this job when the PR is merged, not just closed
+    if: github.event_name != 'pull_request' || github.event.pull_request.merged == true
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/stage-build-container-image-front-end.yml
+++ b/.github/workflows/stage-build-container-image-front-end.yml
@@ -8,24 +8,12 @@ on:
     paths:
         - .github/workflows/stage-build-container-image-front-end.yml
         - front-end/**
-  pull_request:
-    types: [closed]
-    branches:
-      - stage
-    paths:
-        - .github/workflows/stage-build-container-image-front-end.yml
-        - front-end/**
   repository_dispatch:
     types: [stage-deploy-frontend]
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    # Only run this job when:
-    # 1. It's a direct push to stage branch
-    # 2. It's a PR that was merged (not just closed)
-    # 3. It's a repository_dispatch event
-    if: github.event_name == 'repository_dispatch' || github.event_name == 'workflow_dispatch' || github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
このPRはstage環境へのデプロイをstage-automerge.ymlによるマージ時にも実行されるように修正します。

## 変更内容

1. stage-build-container-image-back-end.yml と stage-build-container-image-front-end.yml の両方に以下の変更を追加：
   - repository_dispatch トリガーを追加

2. stage-automerge.yml に以下の変更を追加：
   - マージ成功後に repository_dispatch イベントを発行して、バックエンドとフロントエンドのデプロイワークフローをトリガー

これらの変更により、stage環境へのデプロイは以下の場合に実行されます：
1. stageブランチへの直接プッシュ（既存の動作）
2. stage-automerge.ymlによってPRがstageブランチにマージされた場合（新しい動作）